### PR TITLE
Support pkg/error created stack traces

### DIFF
--- a/rollrus.go
+++ b/rollrus.go
@@ -89,10 +89,6 @@ func ReportPanic(token, env string) {
 // returned by Levels(). See below.
 func (r *Hook) Fire(entry *log.Entry) error {
 	cause, trace := extractError(entry)
-	if cause == nil {
-
-	}
-
 	m := convertFields(entry.Data)
 	if _, exists := m["time"]; !exists {
 		m["time"] = entry.Time.Format(time.RFC3339)

--- a/rollrus.go
+++ b/rollrus.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/pkg/errors"
 	"github.com/stvp/roll"
 )
 
@@ -13,6 +14,12 @@ var defaultTriggerLevels = []log.Level{
 	log.ErrorLevel,
 	log.FatalLevel,
 	log.PanicLevel,
+}
+
+// wellKnownErrorFields are fields that are expected to be of type `error`
+// in priority order.
+var wellKnownErrorFields = []string{
+	"err", "error",
 }
 
 // Hook wrapper for the rollbar Client
@@ -80,28 +87,55 @@ func ReportPanic(token, env string) {
 
 // Fire the hook. This is called by Logrus for entries that match the levels
 // returned by Levels(). See below.
-func (r *Hook) Fire(entry *log.Entry) (err error) {
-	e := fmt.Errorf(entry.Message)
+func (r *Hook) Fire(entry *log.Entry) error {
+	cause, trace := extractError(entry.Data)
+	if cause == nil {
+		cause = fmt.Errorf(entry.Message)
+	}
+
 	m := convertFields(entry.Data)
 	if _, exists := m["time"]; !exists {
 		m["time"] = entry.Time.Format(time.RFC3339)
 	}
 
-	switch entry.Level {
-	case log.FatalLevel, log.PanicLevel:
-		_, err = r.Client.Critical(e, m)
-	case log.ErrorLevel:
-		_, err = r.Client.Error(e, m)
-	case log.WarnLevel:
-		_, err = r.Client.Warning(e, m)
-	case log.InfoLevel:
-		_, err = r.Client.Info(entry.Message, m)
-	case log.DebugLevel:
-		_, err = r.Client.Debug(entry.Message, m)
-	default:
-		return fmt.Errorf("Unknown level: %s", entry.Level)
-	}
+	return r.report(entry, cause, m, trace)
+}
 
+func (r *Hook) report(entry *log.Entry, cause error, m map[string]string, trace []uintptr) (err error) {
+	if entry.Level == log.FatalLevel ||
+		entry.Level == log.PanicLevel ||
+		entry.Level == log.ErrorLevel ||
+		entry.Level == log.WarnLevel {
+
+		if len(trace) == 0 {
+			switch entry.Level {
+			case log.FatalLevel, log.PanicLevel:
+				_, err = r.Client.Critical(cause, m)
+			case log.ErrorLevel:
+				_, err = r.Client.Error(cause, m)
+			case log.WarnLevel:
+				_, err = r.Client.Warning(cause, m)
+			}
+		} else {
+			switch entry.Level {
+			case log.FatalLevel, log.PanicLevel:
+				_, err = r.Client.CriticalStack(cause, trace, m)
+			case log.ErrorLevel:
+				_, err = r.Client.ErrorStack(cause, trace, m)
+			case log.WarnLevel:
+				_, err = r.Client.WarningStack(cause, trace, m)
+			}
+		}
+	} else {
+		switch entry.Level {
+		case log.InfoLevel:
+			_, err = r.Client.Info(entry.Message, m)
+		case log.DebugLevel:
+			_, err = r.Client.Debug(entry.Message, m)
+		default:
+			err = fmt.Errorf("Unknown level: %s", entry.Level)
+		}
+	}
 	return err
 }
 
@@ -131,4 +165,37 @@ func convertFields(fields log.Fields) map[string]string {
 	}
 
 	return m
+}
+
+// extractError attempts to extract an error from a well known field, err or error
+func extractError(fields log.Fields) (cause error, trace []uintptr) {
+	type stackTracer interface {
+		StackTrace() errors.StackTrace
+	}
+
+	for _, f := range wellKnownErrorFields {
+		e, ok := fields[f]
+		if !ok {
+			continue
+		}
+		err, ok := e.(error)
+		if !ok {
+			continue
+		}
+
+		cause = errors.Cause(err)
+		tracer, ok := err.(stackTracer)
+		if ok {
+			trace = copyStackTrace(tracer.StackTrace())
+		}
+		return
+	}
+	return
+}
+
+func copyStackTrace(trace errors.StackTrace) (out []uintptr) {
+	for _, frame := range trace {
+		out = append(out, uintptr(frame))
+	}
+	return
 }

--- a/rollrus.go
+++ b/rollrus.go
@@ -102,39 +102,28 @@ func (r *Hook) Fire(entry *log.Entry) error {
 }
 
 func (r *Hook) report(entry *log.Entry, cause error, m map[string]string, trace []uintptr) (err error) {
-	if entry.Level == log.FatalLevel ||
-		entry.Level == log.PanicLevel ||
-		entry.Level == log.ErrorLevel ||
-		entry.Level == log.WarnLevel {
+	hasTrace := len(trace) > 0
+	level := entry.Level
 
-		if len(trace) == 0 {
-			switch entry.Level {
-			case log.FatalLevel, log.PanicLevel:
-				_, err = r.Client.Critical(cause, m)
-			case log.ErrorLevel:
-				_, err = r.Client.Error(cause, m)
-			case log.WarnLevel:
-				_, err = r.Client.Warning(cause, m)
-			}
-		} else {
-			switch entry.Level {
-			case log.FatalLevel, log.PanicLevel:
-				_, err = r.Client.CriticalStack(cause, trace, m)
-			case log.ErrorLevel:
-				_, err = r.Client.ErrorStack(cause, trace, m)
-			case log.WarnLevel:
-				_, err = r.Client.WarningStack(cause, trace, m)
-			}
-		}
-	} else {
-		switch entry.Level {
-		case log.InfoLevel:
-			_, err = r.Client.Info(entry.Message, m)
-		case log.DebugLevel:
-			_, err = r.Client.Debug(entry.Message, m)
-		default:
-			err = fmt.Errorf("Unknown level: %s", entry.Level)
-		}
+	switch {
+	case hasTrace && level == log.FatalLevel:
+		_, err = r.Client.CriticalStack(cause, trace, m)
+	case hasTrace && level == log.PanicLevel:
+		_, err = r.Client.CriticalStack(cause, trace, m)
+	case hasTrace && level == log.ErrorLevel:
+		_, err = r.Client.ErrorStack(cause, trace, m)
+	case hasTrace && level == log.WarnLevel:
+		_, err = r.Client.WarningStack(cause, trace, m)
+	case level == log.FatalLevel || level == log.PanicLevel:
+		_, err = r.Client.Critical(cause, m)
+	case level == log.ErrorLevel:
+		_, err = r.Client.Error(cause, m)
+	case level == log.WarnLevel:
+		_, err = r.Client.Warning(cause, m)
+	case level == log.InfoLevel:
+		_, err = r.Client.Info(entry.Message, m)
+	case level == log.DebugLevel:
+		_, err = r.Client.Debug(entry.Message, m)
 	}
 	return err
 }

--- a/rollrus_test.go
+++ b/rollrus_test.go
@@ -99,11 +99,11 @@ func TestTimeConversion(t *testing.T) {
 }
 
 func TestExtractError(t *testing.T) {
-	i := make(logrus.Fields)
-	i["err"] = fmt.Errorf("foo bar baz")
+	entry := logrus.NewEntry(nil)
+	entry.Data["err"] = fmt.Errorf("foo bar baz")
 
-	cause, trace := extractError(i)
-	if len(trace) > 0 {
+	cause, trace := extractError(entry)
+	if len(trace) != 0 {
 		t.Fatal("Expected length of trace to be equal to 0, but instead is: ", len(trace))
 	}
 
@@ -112,11 +112,26 @@ func TestExtractError(t *testing.T) {
 	}
 }
 
-func TestExtractErrorFromStackTracer(t *testing.T) {
-	i := make(logrus.Fields)
-	i["err"] = errors.Errorf("foo bar baz")
+func TestExtractErrorDefault(t *testing.T) {
+	entry := logrus.NewEntry(nil)
+	entry.Data["no-err"] = fmt.Errorf("foo bar baz")
+	entry.Message = "message error"
 
-	cause, trace := extractError(i)
+	cause, trace := extractError(entry)
+	if len(trace) != 0 {
+		t.Fatal("Expected length of trace to be equal to 0, but instead is: ", len(trace))
+	}
+
+	if cause.Error() != "message error" {
+		t.Fatalf("Expected error as string to be 'message error', but was instead: %q", cause)
+	}
+}
+
+func TestExtractErrorFromStackTracer(t *testing.T) {
+	entry := logrus.NewEntry(nil)
+	entry.Data["err"] = errors.Errorf("foo bar baz")
+
+	cause, trace := extractError(entry)
 	if len(trace) != 3 {
 		t.Fatal("Expected length of trace to be == 3, but instead is: ", len(trace))
 	}

--- a/rollrus_test.go
+++ b/rollrus_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/pkg/errors"
 	"github.com/stvp/roll"
 )
 
@@ -94,6 +95,34 @@ func TestTimeConversion(t *testing.T) {
 
 	if v != now.Format(time.RFC3339) {
 		t.Fatal("Expected value to equal, but instead it is: ", v)
+	}
+}
+
+func TestExtractError(t *testing.T) {
+	i := make(logrus.Fields)
+	i["err"] = fmt.Errorf("foo bar baz")
+
+	cause, trace := extractError(i)
+	if len(trace) > 0 {
+		t.Fatal("Expected length of trace to be equal to 0, but instead is: ", len(trace))
+	}
+
+	if cause.Error() != "foo bar baz" {
+		t.Fatalf("Expected error as string to be 'foo bar baz', but was instead: %q", cause)
+	}
+}
+
+func TestExtractErrorFromStackTracer(t *testing.T) {
+	i := make(logrus.Fields)
+	i["err"] = errors.Errorf("foo bar baz")
+
+	cause, trace := extractError(i)
+	if len(trace) != 3 {
+		t.Fatal("Expected length of trace to be == 3, but instead is: ", len(trace))
+	}
+
+	if cause.Error() != "foo bar baz" {
+		t.Fatalf("Expected error as string to be 'foo bar baz', but was instead: %q", cause.Error())
 	}
 }
 


### PR DESCRIPTION
Combines github.com/stvp/roll with github.com/pkg/errors to support sending stack traces generated from `errors.Wrap` and friends to rollbar, instead of rollbar's stack walking.

This makes rollrus much more useful since stack traces can represent where the error occurred, not where the log call happened.