### PR TITLE
Update rollrus to support logrus 1.0 (lowercase sirupsen)

### DIFF
--- a/rollrus.go
+++ b/rollrus.go
@@ -22,8 +22,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/stvp/roll"
 )
 

--- a/rollrus_test.go
+++ b/rollrus_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/stvp/roll"
 )
 


### PR DESCRIPTION
Recently, logrus moved to version 1.0. One of the things that was done was to rename the github.com account to lowercase from uppercase. Unfortunately, this means that imports need to be updated everywhere in order to not have compile errors due to case-insensitive import collisions.

See https://github.com/sirupsen/logrus/issues/553 for some more information.