### PR TITLE
Use lowercase sirupsen/logrus import

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # What
 
-Rollrus is what happens when [Logrus](https://github.com/Sirupsen/logrus) meets [Roll](https://github.com/stvp/roll).
+Rollrus is what happens when [Logrus](https://github.com/sirupsen/logrus) meets [Roll](https://github.com/stvp/roll).
 
 When a .Error, .Fatal or .Panic logging function is called, report the details to rollbar via a Logrus hook.
 

--- a/rollrus.go
+++ b/rollrus.go
@@ -1,4 +1,4 @@
-// Package rollrus combines github.com/stvp/roll with github.com/Sirupsen/logrus
+// Package rollrus combines github.com/stvp/roll with github.com/sirupsen/logrus
 // via logrus.Hook mechanism, so that whenever logrus' logger.Error/f(),
 // logger.Fatal/f() or logger.Panic/f() are used the messages are
 // intercepted and sent to rollbar.
@@ -22,8 +22,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/stvp/roll"
 )
 

--- a/rollrus_test.go
+++ b/rollrus_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/stvp/roll"
 )
 


### PR DESCRIPTION
The package github.com/Sirupsen/logrus has been renamed to github.com/sirupsen/logrus. This updates rollrus to import the canonical name.

From https://github.com/sirupsen/logrus/blob/master/README.md:

> Seeing weird case-sensitive problems? It's in the past been possible to import Logrus as both upper- and lower-case. Due to the Go package environment, this caused issues in the community and we needed a standard. Some environments experienced problems with the upper-case variant, so the lower-case was decided. Everything using `logrus` will need to use the lower-case: `github.com/sirupsen/logrus`. Any package that isn't, should be changed.