### PR TITLE
Add ability to set all log levels equal or above a specified one

### DIFF
--- a/rollrus.go
+++ b/rollrus.go
@@ -61,6 +61,21 @@ func WithLevels(levels ...logrus.Level) OptionFunc {
 	}
 }
 
+// WithMinLevel is an OptionFunc that customizes the log.Levels the hook will
+// report on by selecting all levels more severe than the one provided.
+func WithMinLevel(level logrus.Level) OptionFunc {
+	var levels []logrus.Level
+	for _, l := range logrus.AllLevels {
+		if l <= level {
+			levels = append(levels, l)
+		}
+	}
+
+	return func(h *Hook) {
+		h.triggers = levels
+	}
+}
+
 // WithIgnoredErrors is an OptionFunc that whitelists certain errors to prevent
 // them from firing.
 func WithIgnoredErrors(errors ...error) OptionFunc {

--- a/rollrus_test.go
+++ b/rollrus_test.go
@@ -165,6 +165,20 @@ func TestTriggerLevels(t *testing.T) {
 	}
 }
 
+func TestWithMinLevel(t *testing.T) {
+	h := NewHook("", "testing", WithMinLevel(logrus.InfoLevel))
+	expectedLevels := []logrus.Level{
+		logrus.PanicLevel,
+		logrus.FatalLevel,
+		logrus.ErrorLevel,
+		logrus.WarnLevel,
+		logrus.InfoLevel,
+	}
+	if !reflect.DeepEqual(h.Levels(), expectedLevels) {
+		t.Fatal("Expected Levels() to return all levels above Info")
+	}
+}
+
 func TestWithIgnoredErrors(t *testing.T) {
 	h := NewHook("", "testing", WithIgnoredErrors(io.EOF))
 	entry := logrus.NewEntry(nil)

--- a/rollrus_test.go
+++ b/rollrus_test.go
@@ -165,7 +165,7 @@ func TestTriggerLevels(t *testing.T) {
 	}
 }
 
-func TestWithMinLevel(t *testing.T) {
+func TestWithMinLevelInfo(t *testing.T) {
 	h := NewHook("", "testing", WithMinLevel(logrus.InfoLevel))
 	expectedLevels := []logrus.Level{
 		logrus.PanicLevel,
@@ -178,6 +178,41 @@ func TestWithMinLevel(t *testing.T) {
 		t.Fatal("Expected Levels() to return all levels above Info")
 	}
 }
+
+func TestWithMinLevelFatal(t *testing.T) {
+	h := NewHook("", "testing", WithMinLevel(logrus.FatalLevel))
+	expectedLevels := []logrus.Level{
+		logrus.PanicLevel,
+		logrus.FatalLevel,
+	}
+	if !reflect.DeepEqual(h.Levels(), expectedLevels) {
+		t.Fatal("Expected Levels() to return all levels above Fatal")
+	}
+}
+
+func TestLoggingBelowTheMinimumLevelDoesNotFire(t *testing.T) {
+	h := NewHook("", "testing", WithMinLevel(logrus.FatalLevel))
+	l := logrus.New()
+	l.AddHook(h)
+
+	l.Error("This is a test")
+
+	if h.reported {
+		t.Fatal("expected no report to have happened")
+	}
+}
+func TestLoggingAboveTheMinimumLevelDoesFire(t *testing.T) {
+	h := NewHook("", "testing", WithMinLevel(logrus.WarnLevel))
+	l := logrus.New()
+	l.AddHook(h)
+
+	l.Warn("This is a test")
+
+	if !h.reported {
+		t.Fatal("expected report to have happened")
+	}
+}
+
 
 func TestWithIgnoredErrors(t *testing.T) {
 	h := NewHook("", "testing", WithIgnoredErrors(io.EOF))


### PR DESCRIPTION
Hi,

this PR adds a small function to set a minimum log level, instead of having to provide an array of levels.

This mimics logrus' behaviour of specifying a min level, and is useful for our team as we usually want to log everything above a certain threshold.

I implemented it as an OptionFunc to avoid having too many constructors.

