### PR TITLE
Async rollrus

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,10 @@ language: go
 go:
 - 1.6.3
 - 1.7
+- 1.8
+- 1.9
 script:
-- go test -v -race ./...
+- go test -race -bench=. ./...
+env:
+  global:
+    secure: kqtXQIVfFiHzjYsw94RGp60m8tBtHRKkHj2gsNcpuXMF61PkaJ+bZsZpC1JM6bOW0sZIxgsQlYXKCw0WxkJd245n2McrLkYDf7IsdycA+wiufBHDFmZ96OU2mM4DUyW157ECOkldNNqrPSIV8Vdm2LorM4VgptGZ1xrjFULiZsEAbVzzYnIuiu7MV3Xi98NWyNo6TWtMOYf8K/AMs8KKNTldrFZblKtD7dS6ForU0H70nTody3KCmMV+xPXxQI1dYZ7vbfXXmx/id+frr+Ycy8zpfM4nXoOpa5wh/UNngHykzWBevBMrg39lOg86V2JzSt9b6VUGXY9USBTS3juQ7QwD3O24kfelPV056HgCAmK5e2mMPMFqFRgrjJwkJbacOuImvrQP0bGFzOlFj57wynnCezT8VenhJiKSlL57zocc72B5RZYhqUT9IjLNmlIIEd0enmCDJtJVdkKlkO0Gl+X+Cqc/C72N6vFt6yCtetER6tusKeQCW0oPTafBQclBCjIYs9kaH4j+bivh4yTvkyxfqCtdGJMYyj1+UhXfep0LRGljRldv4ltWOq1jG6jywKrpY3h65XrDTSUDeA34NK22ZlhJaIseL+3QHBwy0vQXEJAwzgSnVpaQbCmRdwgyocByOEHurV2jUxtwsDnHGH2uJGNykpkYB/FCzwXxyS8=

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/heroku/rollrus.svg?branch=master)](https://travis-ci.org/heroku/rollrus)&nbsp;[![GoDoc](https://godoc.org/github.com/heroku/rollrus?status.svg)](https://godoc.org/github.com/heroku/rollrus)
+[![Build Status](https://travis-ci.org/heroku/rollrus.svg?branch=master)](https://travis-ci.org/benjamindow/rollrus)&nbsp;[![GoDoc](https://godoc.org/github.com/benjamindow/rollrus?status.svg)](https://godoc.org/github.com/benjamindow/rollrus)
 
 # What
 
@@ -12,4 +12,4 @@ If the error includes a [`StackTrace`](https://godoc.org/github.com/pkg/errors#S
 
 # Usage
 
-Examples available in the [tests](https://github.com/heroku/rollrus/blob/master/rollrus_test.go) or on [GoDoc](https://godoc.org/github.com/heroku/rollrus).
+Examples available in the [tests](https://github.com/benjamindow/rollrus/blob/master/rollrus_test.go) or on [GoDoc](https://godoc.org/github.com/benjamindow/rollrus).

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,40 @@
+package rollrus
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+var vanillaLogger *logrus.Logger
+var rollrusLogger *logrus.Logger
+
+func init() {
+	token := os.Getenv("ROLLBAR_TOKEN")
+	if token == "" {
+		panic("Could not get rollbar token")
+	}
+
+	vanillaLogger = logrus.New()
+	rollrusLogger = logrus.New()
+
+	vanillaLogger.Out = ioutil.Discard
+	rollrusLogger.Out = ioutil.Discard
+
+	rollrus := NewHook(token, "test")
+	rollrusLogger.AddHook(rollrus)
+}
+
+func BenchmarkVanillaLogger(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		vanillaLogger.Error("test")
+	}
+}
+
+func BenchmarkRollrusLogger(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		rollrusLogger.Error("test")
+	}
+}

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -5,11 +5,14 @@ import (
 	"os"
 	"testing"
 
+	"io"
+
 	"github.com/sirupsen/logrus"
 )
 
 var vanillaLogger *logrus.Logger
 var rollrusLogger *logrus.Logger
+var rollrusCloser io.Closer
 
 func init() {
 	token := os.Getenv("ROLLBAR_TOKEN")
@@ -23,8 +26,9 @@ func init() {
 	vanillaLogger.Out = ioutil.Discard
 	rollrusLogger.Out = ioutil.Discard
 
-	rollrus := NewHook(token, "test")
+	rollrus, closer := NewHook(token, "test")
 	rollrusLogger.AddHook(rollrus)
+	rollrusCloser = closer
 }
 
 func BenchmarkVanillaLogger(b *testing.B) {
@@ -37,4 +41,5 @@ func BenchmarkRollrusLogger(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		rollrusLogger.Error("test")
 	}
+	rollrusCloser.Close()
 }

--- a/rollrus.go
+++ b/rollrus.go
@@ -2,12 +2,21 @@ package rollrus
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"time"
+
+	"sync"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/stvp/roll"
 )
+
+type noopCloser struct{}
+
+func (c noopCloser) Close() error {
+	return nil
+}
 
 var defaultTriggerLevels = []log.Level{
 	log.ErrorLevel,
@@ -20,42 +29,59 @@ var defaultTriggerLevels = []log.Level{
 type Hook struct {
 	roll.Client
 	triggers []log.Level
+	entries  chan *log.Entry
+	closed   chan struct{}
+	once     *sync.Once
 }
 
 // Setup a new hook with default reporting levels, useful for adding to
 // your own logger instance.
-func NewHook(token string, env string) *Hook {
+func NewHook(token string, env string) (*Hook, io.Closer) {
 	return NewHookForLevels(token, env, defaultTriggerLevels)
 }
 
 // Setup a new hook with specified reporting levels, useful for adding to
 // your own logger instance.
-func NewHookForLevels(token string, env string, levels []log.Level) *Hook {
-	return &Hook{
+func NewHookForLevels(token string, env string, levels []log.Level) (*Hook, io.Closer) {
+	h := &Hook{
 		Client:   roll.New(token, env),
 		triggers: levels,
+		closed:   make(chan struct{}),
+		entries:  make(chan *log.Entry, 100),
+		once:     new(sync.Once),
 	}
+
+	go h.sendToRollbar()
+
+	return h, h
 }
 
 // SetupLogging sets up logging. If token is not an empty string a rollbar
 // hook is added with the environment set to env. The log formatter is set to a
 // TextFormatter with timestamps disabled, which is suitable for use on Heroku.
-func SetupLogging(token, env string) {
-	setupLogging(token, env, defaultTriggerLevels)
+func SetupLogging(token, env string) io.Closer {
+	return setupLogging(token, env, defaultTriggerLevels)
 }
 
 // SetupLoggingForLevels works like SetupLogging, but allows you to
 // set the levels on which to trigger this hook.
-func SetupLoggingForLevels(token, env string, levels []log.Level) {
-	setupLogging(token, env, levels)
+func SetupLoggingForLevels(token, env string, levels []log.Level) io.Closer {
+	return setupLogging(token, env, levels)
 }
 
-func setupLogging(token, env string, levels []log.Level) {
+func setupLogging(token, env string, levels []log.Level) io.Closer {
 	log.SetFormatter(&log.TextFormatter{DisableTimestamp: true})
 
+	var closer io.Closer
 	if token != "" {
-		log.AddHook(NewHookForLevels(token, env, levels))
+		h, c := NewHookForLevels(token, env, levels)
+		log.AddHook(h)
+		closer = c
+	} else {
+		closer = noopCloser{}
 	}
+
+	return closer
 }
 
 // ReportPanic attempts to report the panic to rollbar using the provided
@@ -81,28 +107,56 @@ func ReportPanic(token, env string) {
 // Fire the hook. This is called by Logrus for entries that match the levels
 // returned by Levels(). See below.
 func (r *Hook) Fire(entry *log.Entry) (err error) {
-	e := fmt.Errorf(entry.Message)
-	m := convertFields(entry.Data)
-	if _, exists := m["time"]; !exists {
-		m["time"] = entry.Time.Format(time.RFC3339)
-	}
-
-	switch entry.Level {
-	case log.FatalLevel, log.PanicLevel:
-		_, err = r.Client.Critical(e, m)
-	case log.ErrorLevel:
-		_, err = r.Client.Error(e, m)
-	case log.WarnLevel:
-		_, err = r.Client.Warning(e, m)
-	case log.InfoLevel:
-		_, err = r.Client.Info(entry.Message, m)
-	case log.DebugLevel:
-		_, err = r.Client.Debug(entry.Message, m)
+	select {
+	case <-r.closed:
+		//do nothing
 	default:
-		return fmt.Errorf("Unknown level: %s", entry.Level)
+		r.entries <- entry
 	}
 
-	return err
+	return nil
+}
+
+func (r *Hook) sendToRollbar() {
+	defer close(r.closed)
+	for entry := range r.entries {
+		e := fmt.Errorf(entry.Message)
+		m := convertFields(entry.Data)
+		if _, exists := m["time"]; !exists {
+			m["time"] = entry.Time.Format(time.RFC3339)
+		}
+
+		var err error
+		switch entry.Level {
+		case log.FatalLevel, log.PanicLevel:
+			_, err = r.Client.Critical(e, m)
+		case log.ErrorLevel:
+			_, err = r.Client.Error(e, m)
+		case log.WarnLevel:
+			_, err = r.Client.Warning(e, m)
+		case log.InfoLevel:
+			_, err = r.Client.Info(entry.Message, m)
+		case log.DebugLevel:
+			_, err = r.Client.Debug(entry.Message, m)
+		default:
+			err = fmt.Errorf("Unknown level: %s", entry.Level)
+		}
+
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Could not send entry to rollbar: %v", err)
+		}
+	}
+}
+
+func (r *Hook) Close() error {
+	r.once.Do(func() {
+		close(r.entries)
+	})
+
+	select {
+	case <-r.closed:
+		return nil
+	}
 }
 
 // Levels returns the logrus log levels that this hook handles

--- a/rollrus_test.go
+++ b/rollrus_test.go
@@ -22,7 +22,7 @@ func ExampleSetupLogging() {
 
 func ExampleNewHook() {
 	log := logrus.New()
-	hook := NewHook("my-secret-token", "production")
+	hook, _ := NewHook("my-secret-token", "production")
 	log.Hooks.Add(hook)
 
 	// This will not be reported to Rollbar


### PR DESCRIPTION
Made rollbar async improved performance from:

```
 2017-11-18 21:15:15 ⌚  andymc-MS-7808 in ~/go/src/github.com/benjamindow/rollrus
± |before ?:2 ✗| → go test -bench=. ./...
goos: linux
goarch: amd64
pkg: github.com/benjamindow/rollrus
BenchmarkVanillaLogger-4   	 1000000	      2758 ns/op
BenchmarkRollrusLogger-4   	      20	  77503141 ns/op
PASS
ok  	github.com/benjamindow/rollrus	4.889s
```

to

```
± |async-rollrus ?:2 ✗| → go test -bench=. ./...
goos: linux
goarch: amd64
pkg: github.com/benjamindow/rollrus
BenchmarkVanillaLogger-4   	  500000	      2892 ns/op
BenchmarkRollrusLogger-4   	  500000	      2612 ns/op
PASS
ok  	github.com/benjamindow/rollrus	3.177s

```