### PR TITLE
When field is not stringer, format value instead

### DIFF
--- a/rollrus.go
+++ b/rollrus.go
@@ -226,7 +226,7 @@ func convertFields(fields logrus.Fields) map[string]string {
 			if s, ok := v.(fmt.Stringer); ok {
 				m[k] = s.String()
 			} else {
-				m[k] = fmt.Sprintf("%+v", t)
+				m[k] = fmt.Sprintf("%+v", v)
 			}
 		}
 	}


### PR DESCRIPTION
I believe the `t` was a typo because it represents the type of the value, not the value itself.