### PR TITLE
Replication test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: go
 go:
 - 1.10.2
+- 1.12
 script:
 - go test -v -race ./...

--- a/rollrus_test.go
+++ b/rollrus_test.go
@@ -259,6 +259,26 @@ type isTemporary interface {
 	Temporary() bool
 }
 
+// https://github.com/go-pg/pg/blob/2ebb4d1d9b890619de2dc9e1dc0085b86f93fc91/internal/error.go#L22
+type PGError struct {
+	m map[byte]string
+}
+func (err PGError) Error() string {
+	return "error"
+}
+
+func TestWithErrorHandlesUnhashableErrors(t *testing.T) {
+	entry := logrus.NewEntry(nil)
+	entry.Message = "This is a test"
+	entry.Data["err"] = PGError{}
+
+	h := NewHook("", "testing")
+	// actually panics
+	if err := h.Fire(entry); err != nil {
+		t.Fatal("unexpected error ", err)
+	}
+}
+
 func TestWithIgnoreErrorFunc(t *testing.T) {
 	h := NewHook("", "testing", WithIgnoreErrorFunc(func(err error) bool {
 		if err == io.EOF {


### PR DESCRIPTION
Failing test for issue #26. This is simplified verification, because I can't import `internal` package from `go-pg`. They don't intend publishing this struct and I don't think they break anything, since they don't have obligation to make hashable `errors`.

Update: this incompatibility seems to be introduced by Go 1.12.

```
-- FAIL: TestWithErrorHandlesUnhashableErrors (0.00s)
panic: runtime error: hash of unhashable type rollrus.PGError [recovered]
	panic: runtime error: hash of unhashable type rollrus.PGError

goroutine 33 [running]:
testing.tRunner.func1(0xc0000fcf00)
	/usr/local/go/src/testing/testing.go:830 +0x392
panic(0x7223e0, 0xc000083370)
	/usr/local/go/src/runtime/panic.go:522 +0x1b5
github.com/chartmogul/rollrus.(*Hook).Fire(0xc0000ba640, 0xc0000aff50, 0x784594, 0x7)
	$GOPATH/src/github.com/chartmogul/rollrus/rollrus.go:182 +0xce
github.com/chartmogul/rollrus.TestWithErrorHandlesUnhashableErrors(0xc0000fcf00)
	$GOPATH/src/github.com/chartmogul/rollrus/rollrus_test.go:277 +0x137
testing.tRunner(0xc0000fcf00, 0x79b278)
	/usr/local/go/src/testing/testing.go:865 +0xc0
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:916 +0x35a
FAIL	github.com/chartmogul/rollrus	0.005s
```