### PR TITLE
Improve ignoredErrors

### DIFF
--- a/rollrus_test.go
+++ b/rollrus_test.go
@@ -263,14 +263,17 @@ type isTemporary interface {
 type PGError struct {
 	m map[byte]string
 }
+
 func (err PGError) Error() string {
 	return "error"
 }
 
+// https://github.com/heroku/rollrus/issues/26
 func TestWithErrorHandlesUnhashableErrors(t *testing.T) {
+	_ = NewHook("", "", WithIgnoredErrors(PGError{m: make(map[byte]string)}))
 	entry := logrus.NewEntry(nil)
 	entry.Message = "This is a test"
-	entry.Data["err"] = PGError{}
+	entry.Data["err"] = PGError{m: make(map[byte]string)}
 
 	h := NewHook("", "testing")
 	// actually panics


### PR DESCRIPTION
This implementation uses a slice of errors compared to a hash. This
could impact performance if the ignoredErrors list is large, but I
suspect it's typically not.

Switching to a slice means the error only needs to be comparable.
Comparatively using a hash meant the error had to be hashable, and
some types that implement error are not. These cases were likely
silently ignored before go1.12.

Fixes #26