### PR TITLE
Fix #29 Improve Causer interface checking

### DIFF
--- a/hook.go
+++ b/hook.go
@@ -150,6 +150,9 @@ func extractError(entry *logrus.Entry) ([]uintptr, error) {
 		}
 
 		cause := errors.Cause(err)
+		if cause == nil {
+			cause = err
+		}
 		tracer, ok := err.(stackTracer)
 		if ok {
 			return copyStackTrace(tracer.StackTrace()), cause


### PR DESCRIPTION
Cause method on error could return nil.
If it returns nil the error is set back to the original error.