### PR TITLE
Add option to enable person context using special fields

### DIFF
--- a/options.go
+++ b/options.go
@@ -51,3 +51,11 @@ func WithIgnoreFunc(fn func(err error, fields map[string]interface{}) bool) Opti
 		h.ignoreFunc = fn
 	}
 }
+
+// WithPersonFunc is an OptionFunc that will set the person in the Rollbar alert
+// using the special error fields user_id, user_name and user_email
+func WithPersonFunc(setPerson bool) OptionFunc {
+	return func(h *Hook) {
+		h.setPerson = setPerson
+	}
+}


### PR DESCRIPTION
Adds `WithPersonFunc` `OptionFunc` that enables using `NewPersonContext` from the following special fields:

- `user_id`
- `user_name`
- `user_email`

With it enabled and using these fields you will see the Person populated in rollbar under the issue's `People` section:

<img width="933" alt="Screen Shot 2020-07-22 at 22 30 22" src="https://user-images.githubusercontent.com/24260/88196106-03783d00-cc6b-11ea-906f-289e2cc30041.png">

And also all the errors grouped by the person:

<img width="940" alt="Screen Shot 2020-07-22 at 22 29 57" src="https://user-images.githubusercontent.com/24260/88196161-12f78600-cc6b-11ea-924f-de50aeb202d6.png">

Closes #46 